### PR TITLE
remove FlowState and FlowStateChangedDate from quick filter

### DIFF
--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -153,6 +153,13 @@ Ext.define("custom-grid-with-deep-export", {
                         stateId: this.getModelScopedStateId(currentModelName, 'filters'),
                         modelNames: this.modelNames,
                         inlineFilterPanelConfig: {
+                            advancedFilterPanelConfig: {
+                                advancedFilterRowsConfig:{
+                                    propertyFieldConfig: {
+                                        blackListFields: ['FlowState','FlowStateChangedDate']
+                                    }
+                                }
+                            },
                             quickFilterPanelConfig: {
                                 portfolioItemTypes: this.portfolioItemTypes,
                                 modelName: currentModelName,

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -159,7 +159,10 @@ Ext.define("custom-grid-with-deep-export", {
                                 whiteListFields: [
                                     'Tags',
                                     'Milestones'
-                                ]
+                                ],
+                                addQuickFilterConfig: {
+                                    blackListFields: ['FlowState','FlowStateChangedDate']
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Flow State was introduced after the AppSDK was released. This field does not work out of the box, so this change will hide it from the list of available filter fields